### PR TITLE
Fix code scanning alert no. 10: Uncontrolled data used in path expression

### DIFF
--- a/bazarr/app/ui.py
+++ b/bazarr/app/ui.py
@@ -75,7 +75,10 @@ def catch_all(path):
 
     # PWA Assets are returned from frontend root folder
     if path in pwa_assets or path.startswith('workbox-'):
-        return send_file(os.path.join(frontend_build_path, path))
+        fullpath = os.path.normpath(os.path.join(frontend_build_path, path))
+        if not fullpath.startswith(frontend_build_path):
+            return abort(403, description="Access denied")
+        return send_file(fullpath)
 
     auth = True
     if settings.auth.type == 'basic':


### PR DESCRIPTION
Fixes [https://github.com/jdfalk/bazarr-cockroachdb/security/code-scanning/10](https://github.com/jdfalk/bazarr-cockroachdb/security/code-scanning/10)

To fix the problem, we need to ensure that the constructed file path is contained within a safe root folder. We can achieve this by normalizing the path using `os.path.normpath` and then checking that the normalized path starts with the root folder (`frontend_build_path`). This will prevent directory traversal attacks by ensuring that the user cannot escape the intended directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
