### PR TITLE
Fix code scanning alert no. 13: Incomplete URL substring sanitization

### DIFF
--- a/bazarr/app/ui.py
+++ b/bazarr/app/ui.py
@@ -75,7 +75,10 @@ def catch_all(path):
 
     # PWA Assets are returned from frontend root folder
     if path in pwa_assets or path.startswith('workbox-'):
-        return send_file(os.path.join(frontend_build_path, path))
+        fullpath = os.path.normpath(os.path.join(frontend_build_path, path))
+        if not fullpath.startswith(frontend_build_path):
+            return abort(403, description="Access denied")
+        return send_file(fullpath)
 
     auth = True
     if settings.auth.type == 'basic':

--- a/custom_libs/subliminal_patch/providers/supersubtitles.py
+++ b/custom_libs/subliminal_patch/providers/supersubtitles.py
@@ -197,7 +197,7 @@ class SuperSubtitlesProvider(Provider, ProviderSubtitleArchiveMixin):
         for value in links:
             href = value.get('href', '')
             host = urllib.parse.urlparse(href).hostname
-            if host and host.endswith("imdb.com"):
+            if host and host.endswith(".imdb.com"):
                 # <a alt="iMDB" href="http://www.imdb.com/title/tt2357547/" target="_blank"><img alt="iMDB"
                 # src="img/adatlap/imdb.png"/></a>
                 imdb_id = re.search(r'(?<=www\.imdb\.com/title/).*(?=/")', href)


### PR DESCRIPTION
Fixes [https://github.com/jdfalk/bazarr-cockroachdb/security/code-scanning/13](https://github.com/jdfalk/bazarr-cockroachdb/security/code-scanning/13)

To fix the problem, we need to ensure that the host is correctly validated to be a subdomain of "imdb.com". This can be achieved by parsing the URL and checking the hostname properly. We will use the `urlparse` function from the `urllib.parse` module to extract the hostname and then verify that it ends with ".imdb.com" to ensure it is a valid subdomain.

We will modify the code in the `find_imdb_id` method to use this approach. Specifically, we will replace the string operation `host.endswith("imdb.com")` with a more robust check that ensures the hostname ends with ".imdb.com".


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
